### PR TITLE
TOOLS-2525 Everything needs to stop cloning with git:// URLs (missed package-lock.json)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "config-agent",
-    "version": "1.8.4",
+    "version": "1.8.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -158,8 +158,8 @@
             }
         },
         "hogan.js": {
-            "version": "git+https://github.com/joyent/hogan.js.git#7d34ba7536b6d398ae97ea359ce6f4f005a40abb",
-            "from": "git+https://github.com/joyent/hogan.js.git#7d34ba7",
+            "version": "git+https://github.com/joyent/hogan.js.git#c5cb8e8ee3fd466e3559627159320579f014fe85",
+            "from": "git+https://github.com/joyent/hogan.js.git#c5cb8e8",
             "requires": {
                 "mkdirp": "0.3.0",
                 "nopt": "1.0.10"


### PR DESCRIPTION
This is causing Jenkins builds that include config-agent to fail with the following error:

```13:25:56  /root/data/jenkins/workspace/joyent-org_sdc-cloudapi_PR-108/deps/eng/tools/agent-prebuilt.sh \
13:25:56  	-b 'PR-108' \
13:25:56  	-B 'master' \
13:25:56  	-c '/var/tmp/agent-cache.root' \
13:25:56  	-p 'config-agent-.*.tar.gz' \
13:25:56  	-r 'sdc-config-agent' \
13:25:56  	-t 'distclean release' \
13:25:56  	-u 'https://github.com/joyent/sdc-config-agent.git' clone
13:25:56  ERROR: uncommitted changes in /var/tmp/agent-cache.root/sdc-config-agent
13:25:56  Please commit these before attempting to update.
13:25:56  make: *** [deps/eng/tools/mk/Makefile.agent_prebuilt.targ:71: CONFIG-prebuilt-clone] Error 1
```

This happens because hogan.js was updated, but the package-lock.json wasn't also updated, so when the build installs hogan, package-lock.json is modified, leaving the working directory dirty.